### PR TITLE
Fix error message due to new API requirements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ Ultimately you just need to put the sensor in the filament path but the exact mo
 I have included STLs for a 0.5mm offset mount for the sensor and tube holders that fit into 6mm wide 2020 channels as a starting point. If you design a nice mount for yourself feel free to submit it as a pull request.
 
 # Software
+
+## Disclaimer
+This version of the code requires Klipper commit [`272e815`](https://github.com/Klipper3d/klipper/commit/272e815522b0bc8e0806e052b73a5cc1af979cd7) or newer.  
+Using an older Klipper version may cause compatibility issues.
+
 ## Installing the software
 Copy **filament_width_sensor_hall_mlx90395.py** and **filament_width_compensation.py** from the "Software" folder into your klipper install under "klippy/extras/" and restart the klipper service.
 

--- a/Software/filament_width_compensation.py
+++ b/Software/filament_width_compensation.py
@@ -92,16 +92,16 @@ class FilamentWidthCompensation:
         runout = (not self.runout_active or reading > self.runout_dia) and (not self.oversize_active or reading < self.oversize_dia)
 
         if self.runout_delay <= 0:
-            self.runout_helper.note_filament_present(runout)
+            self.runout_helper.note_filament_present(eventtime, is_filament_present=runout)
         else:
             if runout:
                 self.runoutOccured = True
                 self.runoutPosition = current_epos + self.measurement_delay
             if self.runoutOccured and current_epos + self.runout_delay >= self.runoutPosition:
-                self.runout_helper.note_filament_present(False)
+                self.runout_helper.note_filament_present(eventtime, is_filament_present=False)
                 self.runoutOccured = False
             else:
-                self.runout_helper.note_filament_present(True)
+                self.runout_helper.note_filament_present(eventtime, is_filament_present=True)
 
         while len(self.filament_array) > 0 and self.filament_array[0][0] <= current_epos:
             self.filament_array.pop(0)


### PR DESCRIPTION
Fix: Update RunoutHelper.note_filament_present() calls to match new API.

I can't say 100% for sure, but I think [this commit](https://github.com/Klipper3d/klipper/commit/272e815522b0bc8e0806e052b73a5cc1af979cd7) in klipper caused the error.

Error message which was fixed with this change:
```
Unhandled exception during run
Traceback (most recent call last):
  File "/home/simon/klipper/klippy/klippy.py", line 176, in run
    self.reactor.run()
  File "/home/simon/klipper/klippy/reactor.py", line 292, in run
    g_next.switch()
  File "/home/simon/klipper/klippy/reactor.py", line 340, in _dispatch_loop
    timeout = self._check_timers(eventtime, busy)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/simon/klipper/klippy/reactor.py", line 158, in _check_timers
    t.waketime = waketime = t.callback(eventtime)
                            ^^^^^^^^^^^^^^^^^^^^^
  File "/home/simon/klipper/klippy/extras/filament_width_compensation.py", line 95, in update_event
    self.runout_helper.note_filament_present(runout)
TypeError: RunoutHelper.note_filament_present() missing 1 required positional argument: 'is_filament_present'
Transition to shutdown state: Unhandled exception during run
```